### PR TITLE
[autopatch] Add Common Platform Enumeration id to manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Extendable continuous integration server
 
 **Shipped version:** 2.346.2~ynh1
 
+
 ## Screenshots
 
 ![Screenshot of Jenkins](./doc/screenshots/screenshot1.png)

--- a/README_fr.md
+++ b/README_fr.md
@@ -17,7 +17,8 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Serveur d'intégration continue extensible
 
-**Version incluse :** 2.346.2~ynh1
+**Version incluse :** 2.346.2~ynh1
+
 
 ## Captures d'écran
 


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to add the (optional but recommended if relevant) Common Platform Enumeration (CPE) id, which is sort of a standard id for applications, defined by the NIST.

In particular, Yunohost may use this is in the future to easily track CVE (=security reports) related to apps.

The CPE may be obtained by searching here: https://nvd.nist.gov/products/cpe/search. For example, for Nextcloud, the CPE is 'cpe:2.3:a:nextcloud:nextcloud' (no need to include the version number)").