### PR TITLE
Fixes YunoHost-Apps/jenkins_ynh#108

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -115,12 +115,17 @@ ynh_add_nginx_config
 ynh_script_progression --message="Installing Jenkins..."
 
 # Download jenkins deb file and install it.
-dpkg --install --force-confnew ../conf/jenkins.deb
+dpkg --install --force-confnew ../conf/jenkins.deb || true
+dpkg_install_failed=$(dpkg-query -f '${status} ${package}\n' -W | awk '$4 ~ /^jenkins.*/ && $3 != "installed" {print $4}' | wc -l)
+
+if [[ $dpkg_install_failed -ge 1 ]]; then
+  ynh_print_warn --message="The service jenkins cannot be started for now."
+fi
 
 #=================================================
 # SETUP APPLICATION
 #=================================================
-ynh_script_progression --message="Setuping application..."
+ynh_script_progression --message="Setuping application on port $port..."
 
 cat >> "$final_path/jenkins.install.InstallUtil.lastExecVersion" <<EOF
 $jenkins_version
@@ -137,6 +142,10 @@ ynh_replace_string --match_string="Environment=\"JENKINS_PORT=8080\"" --replace_
 systemctl daemon-reload --quiet
 
 ynh_systemd_action --service_name=$app --action="restart" --line_match="Started Jenkins Continuous Integration Server" --log_path="systemd"
+
+if [[ $dpkg_install_failed -ge 1 ]]; then
+  dpkg --configure -a
+fi
 
 #=================================================
 # INSTALL PLUGINS


### PR DESCRIPTION
## Problem

After the .deb file is installed, dpkg tries to start the service on the default port 8080.

## Solution

This fix ensure that ynh rollback won't be triggered by dpkg during installation of the .deb file. First, the `dpkg --install` error is silenced. Then `dpkg-query` is used to detect an improperly installed jenkins package. Next, after the port has been updated and the service restarted, `dpkg --configure -a` is executed to finish configuration of the partially installed jenkins package.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
