### PR TITLE
Fixes #108

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Extendable continuous integration server
 
-**Shipped version:** 2.401.2~ynh1
+**Shipped version:** 2.401.2~ynh2
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n’avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) po
 
 Serveur d'intégration continue extensible
 
-**Version incluse :** 2.401.2~ynh1
+**Version incluse :** 2.401.2~ynh2
 
 ## Captures d’écran
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Extendable continuous integration server",
         "fr": "Serveur d'intégration continue extensible"
     },
-    "version": "2.401.2~ynh1",
+    "version": "2.401.2~ynh2",
     "url": "https://jenkins.io/index.html",
     "upstream": {
         "license": "MIT",


### PR DESCRIPTION
## Problem

Fix #108 . After the .deb file is installed, dpkg tries to start the service on the default port 8080.

## Solution

This fix ensure that ynh rollback won't be triggered by dpkg during installation of the .deb file. First, the `dpkg --install` error is silenced. Then `dpkg-query` is used to detect an improperly installed jenkins package. Next, after the port has been updated and the service restarted, `dpkg --configure -a` is executed to finish configuration of the partially installed jenkins package.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
