### PR TITLE
Replace deprecated plugins during installation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -173,7 +173,7 @@ $jenkins_plugin_manager --plugins gradle	# Gradle Plugin
 $jenkins_plugin_manager --plugins workflow-aggregator	# Pipeline
 $jenkins_plugin_manager --plugins pipeline-stage-view	# Pipeline: Stage View Plugin
 $jenkins_plugin_manager --plugins git	# Git plugin
-$jenkins_plugin_manager --plugins github-organization-folder	# GitHub Organization Folder Plugin
+$jenkins_plugin_manager --plugins github-branch-source	# GitHub Branch Source Plugin
 $jenkins_plugin_manager --plugins subversion	# Subversion Plug-in
 $jenkins_plugin_manager --plugins email-ext	# Email Extension Plugin
 $jenkins_plugin_manager --plugins ssh-slaves	# SSH Slaves plugin


### PR DESCRIPTION
## Problem

- *Fix #118*

## Solution

Do two replacements:

- *Replace [GitHub Organization Folder Plugin](https://plugins.jenkins.io/github-organization-folder) with [GitHub Branch Source](https://plugins.jenkins.io/github-branch-source/)*
- *Replace [Pipeline: Deprecated Groovy Libraries](https://plugins.jenkins.io/workflow-cps-global-lib) with [Pipeline Groovy Lib](https://plugins.jenkins.io/pipeline-groovy-lib/)*

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
