### PR TITLE
Fix upgrade and restore for alt ports

### DIFF
--- a/check_process
+++ b/check_process
@@ -43,6 +43,7 @@
 		upgrade=1	from_commit=4733662adabc01ea1e29ca0bf55c45f204bb1857
 		backup_restore=1
 		multi_instance=0
+		port_already_use=1 (8080)
 		change_url=1
 ;;; Options
 Email=

--- a/scripts/restore
+++ b/scripts/restore
@@ -78,18 +78,27 @@ ynh_script_progression --message="Installing Jenkins..."
 
 # Download jenkins deb file and install it.
 ynh_setup_source --dest_dir="../conf"
-dpkg --install --force-confnew ../conf/jenkins.deb
+dpkg --install --force-confnew ../conf/jenkins.deb || true
+dpkg_install_failed=$(dpkg-query -f '${status} ${package}\n' -W | awk '$4 ~ /^jenkins.*/ && $3 != "installed" {print $4}' | wc -l)
+
+if [[ $dpkg_install_failed -ge 1 ]]; then
+  ynh_print_warn --message="The service jenkins cannot be started for now."
+fi
 
 #=================================================
 # SETUP APPLICATION
 #=================================================
-ynh_script_progression --message="Setuping application..."
+ynh_script_progression --message="Setuping application on port $port..."
 
 ynh_replace_string --match_string="Environment=\"JENKINS_PORT=8080\"" --replace_string="Environment=\"JENKINS_PORT=$port\"\nEnvironment=\"JENKINS_PREFIX=$path_url\"" --target_file="/lib/systemd/system/jenkins.service"
 
 systemctl daemon-reload --quiet
 
 ynh_systemd_action --service_name=$app --action="restart" --line_match="Started" --log_path="systemd"
+
+if [[ $dpkg_install_failed -ge 1 ]]; then
+  dpkg --configure -a
+fi
 
 #=================================================
 # RESTORE THE APP MAIN DIR

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -116,18 +116,27 @@ then
 	chmod -R o-rwx "$final_path"
 	chown -R $app:$app "$final_path"
 
-	dpkg --install --force-confnew ../conf/jenkins.deb
+	dpkg --install --force-confnew ../conf/jenkins.deb || true
+	dpkg_install_failed=$(dpkg-query -f '${status} ${package}\n' -W | awk '$4 ~ /^jenkins.*/ && $3 != "installed" {print $4}' | wc -l)
+	
+	if [[ $dpkg_install_failed -ge 1 ]]; then
+	  ynh_print_warn --message="The service jenkins cannot be started for now."
+	fi
 
 	#=================================================
 	# SETUP APPLICATION
 	#=================================================
-	ynh_script_progression --message="Setuping application..."
+	ynh_script_progression --message="Setuping application on port $port..."
 
 	ynh_replace_string --match_string="Environment=\"JENKINS_PORT=8080\"" --replace_string="Environment=\"JENKINS_PORT=$port\"\nEnvironment=\"JENKINS_PREFIX=$path_url\"" --target_file="/lib/systemd/system/jenkins.service"
 
 	systemctl daemon-reload --quiet
 
 	ynh_systemd_action --service_name=$app --action="restart" --line_match="Started" --log_path="systemd"
+
+	if [[ $dpkg_install_failed -ge 1 ]]; then
+	  dpkg --configure -a
+	fi
 fi
 
 #=================================================


### PR DESCRIPTION
## Problem

- Fix https://github.com/YunoHost-Apps/jenkins_ynh/issues/121

## Solution

- Apply changes from https://github.com/YunoHost-Apps/jenkins_ynh/pull/109 for alternative port (if default port is already in use) to upgrade and restore scripts.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
