### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -77,7 +77,7 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Installing Jenkins..."
 
 # Download jenkins deb file and install it.
-ynh_setup_source --dest_dir="../conf"
+ynh_setup_source --dest_dir="../conf" --full_replace=1
 dpkg --install --force-confnew ../conf/jenkins.deb
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -110,8 +110,8 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..."
 	# Download jenkins deb file and install it.
-	ynh_setup_source --dest_dir="../conf"
-	ynh_setup_source --source_id="jenkins-plugin-manager" --dest_dir="$final_path"
+	ynh_setup_source --dest_dir="../conf" --full_replace=1
+	ynh_setup_source --source_id="jenkins-plugin-manager" --dest_dir="$final_path" --full_replace=1
 	chmod 750 "$final_path"
 	chmod -R o-rwx "$final_path"
 	chown -R $app:$app "$final_path"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```