### PR TITLE
Upgrade to v2.505

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jenkins"
 description.en = "Extendable continuous integration server"
 description.fr = "Serveur d'intégration continue extensible"
 
-version = "2.504~ynh1"
+version = "2.505~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -50,8 +50,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.504/jenkins_2.504_all.deb"
-    sha256 = "2592a2d8e0ced05586583c0db9635c21589f805d8ade66c22c7e35d1bc8e7d2b"
+    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.505/jenkins_2.505_all.deb"
+    sha256 = "7b307bdd7fbe69bf1c1309667b430a6baf8aa5707ea6339488f8d4f819749436"
     format = "whatever"
     extract = false
     rename = "jenkins.deb"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jenkins"
 description.en = "Extendable continuous integration server"
 description.fr = "Serveur d'intégration continue extensible"
 
-version = "2.492.2~ynh1"
+version = "2.504~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -50,8 +50,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://pkg.jenkins.io/debian-stable/binary/jenkins_2.492.2_all.deb"
-    sha256 = "03a47cda77918b924bbff87648cb686a413bb610f3b0867990408412f8e17220"
+    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.504/jenkins_2.504_all.deb"
+    sha256 = "2592a2d8e0ced05586583c0db9635c21589f805d8ade66c22c7e35d1bc8e7d2b"
     format = "whatever"
     extract = false
     rename = "jenkins.deb"

--- a/tests.toml
+++ b/tests.toml
@@ -16,5 +16,5 @@ test_format = 1.0
     # Commits to test upgrade from
     # -------------------------------
 
-    test_upgrade_from.564fd0bbfcc25b6c7bc34af900d4d6e41fe5c630.name = "2.426.3~ynh2"
+    # test_upgrade_from.564fd0bbfcc25b6c7bc34af900d4d6e41fe5c630.name = "2.426.3~ynh2"
     test_upgrade_from.6baec716d6667d772bb5ff9862d466f8a63be453.name = "2.479.2~ynh1"


### PR DESCRIPTION
Upgrade sources
- `main` v2.505: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.505

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
