### PR TITLE
Upgrade to v2.506

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jenkins"
 description.en = "Extendable continuous integration server"
 description.fr = "Serveur d'intégration continue extensible"
 
-version = "2.504~ynh1"
+version = "2.505~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -50,8 +50,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.504/jenkins_2.504_all.deb"
-    sha256 = "2592a2d8e0ced05586583c0db9635c21589f805d8ade66c22c7e35d1bc8e7d2b"
+    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.505/jenkins_2.505_all.deb"
+    sha256 = "7b307bdd7fbe69bf1c1309667b430a6baf8aa5707ea6339488f8d4f819749436"
     format = "whatever"
     extract = false
     rename = "jenkins.deb"

--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "Jenkins"
 description.en = "Extendable continuous integration server"
 description.fr = "Serveur d'intégration continue extensible"
 
-version = "2.505~ynh1"
+version = "2.506~ynh1"
 
 maintainers = ["yalh76"]
 
@@ -50,8 +50,8 @@ ram.runtime = "50M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.505/jenkins_2.505_all.deb"
-    sha256 = "7b307bdd7fbe69bf1c1309667b430a6baf8aa5707ea6339488f8d4f819749436"
+    url = "https://github.com/jenkinsci/jenkins/releases/download/jenkins-2.506/jenkins_2.506_all.deb"
+    sha256 = "66c3257aee4c07191593f7b217fb76a8a450d7fa947996e7cf2d49cd85745274"
     format = "whatever"
     extract = false
     rename = "jenkins.deb"


### PR DESCRIPTION
Upgrade sources
- `main` v2.506: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.506

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
